### PR TITLE
Adds Decision & Event chain to learn warrior & craftsman skills

### DIFF
--- a/MEP/decisions/learn_craft_decisions.txt
+++ b/MEP/decisions/learn_craft_decisions.txt
@@ -1,0 +1,28 @@
+decisions = {
+	## Learn crafting abilities ##
+	learn_craft_abilities = {
+		is_high_prio = yes
+		potential = {
+			or = {
+				culture = culture_noldor
+				culture_group = culture_group_dwarves
+			}
+			ai = no
+			age = 16
+			NOT = { has_character_flag = learn_craft }
+			NOT = { trait = incapable }
+			has_character_flag = special_decisions_open
+		}
+		allow = {
+			prestige = 200
+			piety = 200
+			wealth = 250
+		}
+		effect = {
+			set_character_flag = learn_craft
+			narrative_event = { id = lrncraft.1 }
+			prestige = -200
+			piety = -200
+		}
+	}
+}

--- a/MEP/decisions/learn_warrior_decisions.txt
+++ b/MEP/decisions/learn_warrior_decisions.txt
@@ -1,0 +1,35 @@
+decisions = {
+	## Learn warrior skills abilities ##
+	learn_warrior_abilities = {
+		is_high_prio = yes
+		potential = {
+			or = {
+				trait = dwarven
+				trait = elf
+				has_character_flag = obj_become_elf_warrior
+			}
+			ai = no
+			age = 16
+			NOT = { has_character_flag = learn_war }
+			NOT = { trait = incapable }
+			NOT = { 
+				or = {
+				
+				trait = legendary_warrior
+				}
+			}
+			has_character_flag = special_decisions_open
+		}
+		allow = {
+			prestige = 200
+			piety = 200
+			wealth = 250
+		}
+		effect = {
+			set_character_flag = learn_war
+			narrative_event = { id = learnwarrior.1 }
+			prestige = -200
+			piety = -200
+		}
+	}
+}

--- a/MEP/events/craft_learning_event.txt
+++ b/MEP/events/craft_learning_event.txt
@@ -1,0 +1,146 @@
+namespace = learncraft
+
+#
+#
+#
+
+### Learn and improve crafting skills  ###
+narative_event = {
+	id = learncraft.1
+	title = "EVTTITlearncraft.1" # I should learn to craft. 
+	desc = "EVTDESClearncraft.1" # I want to learn how to craft,
+	picture = GFX_evt_ring_craft
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTAlearncraft.1" # I'll learn how to craft!
+		trigger = {
+			NOT = {
+				trait = legendary_craftsman
+			}
+		}
+		character_event = { id = learncraft.2 days = 10 }
+		wealth = -250
+	}
+	
+	option = {
+		name = "EVTOPTBlearncraft.1" # I can't pay that!
+		clr_character_flag = learn_craft
+	}
+}
+
+### Actual event to learn how to craft ###
+character_event = {
+	id = learncraft.2
+	title = "EVTTITlearncraft.2"
+	desc = "EVTDESClearncraft.2"
+	picture = GFX_evt_ring_craft
+
+	is_triggered_only = yes
+
+	option = {
+		name = "EVTOPTAlearncraft.2" ## Chance to learn
+		if = {
+			limit = {
+				trait = legendary_craftman
+				age = 1
+				not = {
+					trait = master_craftsman
+					trait = skilled_craftsman
+					trait = craftman
+				}
+			}
+			clr_character_flag = learn_craft ## I am the best already!
+		}
+		if = {
+			limit = {
+				trait = master_craftsman
+				age = 1
+				not = {
+					trait = legendary_craftman
+					trait = skilled_craftsman
+					trait = craftman
+				}
+			}
+			random = {
+				chance = 20
+				add_trait = legendary_craftman
+				remove_trait = master_craftsman
+			}
+			character_event = { id = learncraft.3 days = 90 } ## Lets try to improve!
+		}
+		if = {
+			limit = {
+				trait = skilled_craftsman
+				age = 1
+				not = {
+					trait = legendary_craftman
+					trait = master_craftsman
+					trait = craftman
+				}
+			}
+			random = {
+				chance = 50
+				add_trait = master_craftsman
+				remove_trait = skilled_craftsman
+			}
+			character_event = { id = learncraft.3 days = 70 } ##
+		}
+		if = {
+			limit = {
+				trait = craftsman
+				age = 1
+				not = {
+					trait = legendary_craftman
+					trait = master_craftsman
+					trait = skilled_craftsman
+				}
+			}
+			random = {
+				chance = 30
+				add_trait = skilled_craftsman
+				remove_trait = craftsman
+			}
+			character_event = { id = learncraft.3 days = 60 } ##
+		}
+		if = {
+			limit = {
+				age = 1
+				not = {
+					trait = legendary_craftman
+					trait = master_craftsman
+					trait = skilled_craftsman
+					trait = craftsman
+				}
+			}
+			random = {
+				chance = 30
+				add_trait = craftsman
+			}
+			character_event = { id = learncraft.3 days = 50 } ## I can try again!
+		}
+	}
+}
+
+character_event = {
+	id = learncraft.3
+	title = "EVTTITlearncraft.3"
+	desc = "EVTDESClearncraft.3"
+	picture = GFX_evt_ring_craft
+
+	is_triggered_only = yes
+
+	option = {
+		name = "EVTOPTAlearncraft.3" ##
+		clr_character_flag = learn_craft
+	}
+}
+		
+		
+
+		
+		
+		
+		
+		

--- a/MEP/events/warrior_learning_event.txt
+++ b/MEP/events/warrior_learning_event.txt
@@ -1,0 +1,251 @@
+namespace = learnwarrior
+
+#
+#
+#
+
+### Learn and improve warrior skills (ELF)  ###
+narrative_event = {
+	id = learnwarrior.1
+	title = "EVTTITlearnwarrior.1" # I should learn to craft. 
+	desc = "EVTDESClearnwarrior.1" # I want to learn how to craft,
+	picture = GFX_evt_battle_duel
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVTOPTAlearnwarrior.1" # I'll learn how to become a true elf warrior!
+		trigger = {
+			NOT = {
+				culture_group = culture_group_dwarves
+				trait = legendary_warrior
+				trait = dwarven
+			}
+		}
+		character_event = { id = learnwarrior.2 days = 30 }
+		wealth = -250
+	}
+	
+		option = {
+		name = "EVTOPTBlearnwarrior.1" # I'll learn how to become a true dwarf warrior!
+		trigger = {
+			NOT = {
+				culture_group = culture_group_moriquendi
+				culture_group = culture_group_umanyar
+				culture_group = culture_group_amanyar
+				culture_group = culture_group_quendi
+				trait = elf
+				trait = dragon_slayer
+			}
+		}
+		character_event = { id = learnwarrior.4 days = 30 }
+		wealth = -250
+	}
+	
+	option = {
+		name = "EVTOPTClearnwarrior.1" # I can't pay that!
+		clr_character_flag = learn_war
+	}
+}
+
+### Actual event to learn how to craft ###
+character_event = {
+	id = learnwarrior.2
+	title = "EVTTITlearnwarrior.2"
+	desc = "EVTDESClearnwarrior.2"
+	picture = GFX_evt_battle_duel
+
+	is_triggered_only = yes
+
+	option = {
+		name = "EVTOPTAlearnwarrior.2" ## Time to learn try!
+		if = {
+			limit = {
+				trait = legendary_warrior
+				age = 1
+				not = {
+					trait = great_elf
+					trait = trained_elf
+					trait = pacifist_elf
+				}
+			}
+			clr_character_flag = learn_war ## I am the best already!
+		}		
+		if = {
+			limit = {
+				trait = great_elf
+				age = 1
+				not = {
+					trait = legendary_warrior
+					trait = trained_elf
+					trait = pacifist_elf
+				}
+			}
+			random = {
+				chance = 20
+				add_trait = legendary_warrior
+				remove_trait = great_elf
+			}
+		}
+		if = {
+			limit = {
+				trait = trained_elf
+				age = 1
+				not = {
+					trait = legendary_warrior
+					trait = great_elf
+					trait = pacifist_elf
+				}
+			}
+			random = {
+				chance = 40
+				add_trait = great_elf
+				remove_trait = trained_elf
+			}
+			character_event = { id = learnwarrior.3 days = 70 } ## I can try again!
+		}
+		if = {
+			limit = {
+				trait = pacifist_elf
+				age = 1
+				not = {
+					trait = legendary_warrior
+					trait = great_elf
+					trait = trained_elf
+				}
+			}
+			random = {
+				chance = 50
+				add_trait = trained_elf
+				remove_trait = pacifist_elf
+			}
+			character_event = { id = learnwarrior.3 days = 60 } ## I can try again!
+		}
+		character_event = { id = learnwarrior.3 days = 90 } ## I can try again!
+		if = {
+			limit = {
+				age = 1
+				not = {
+					trait = legendary_warrior
+					trait = great_elf
+					trait = trained_elf
+					trait = pacifist_elf
+				}
+			}
+			random = {
+				chance = 30
+				add_trait = pacifist_elf
+			}
+			character_event = { id = learnwarrior.3 days = 50 } ## I can try again!
+		}
+	}
+}
+
+character_event = {
+	id = learnwarrior.3
+	title = "EVTTITlearnwarrior.3"
+	desc = "EVTDESClearnwarrior.3"
+	picture = GFX_evt_battle_duel
+
+	is_triggered_only = yes
+
+	option = {
+		name = "EVTOPTAlearnwarrior.3" ##
+		clr_character_flag = learn_war
+	}
+}
+
+### Learn and improve warrior skills (DWARF)  ###
+character_event = {
+	id = learnwarrior.4
+	title = "EVTTITlearnwarrior.4"
+	desc = "EVTDESClearnwarrior.4"
+	picture = GFX_evt_battle_duel
+
+	is_triggered_only = yes
+
+	option = {
+		name = "EVTOPTAlearnwarrior.4" ## Time to learn try!
+		if = {
+			limit = {
+				trait = dragon_slayer
+				age = 1
+				not = {
+					trait = great_axeman
+					trait = trained_dwarf
+					trait = dwarf_warrior
+				}
+			}
+			clr_character_flag = learn_war ## I am the best already!
+		}
+		if = {
+			limit = {
+				trait = great_axeman
+				age = 1
+				not = {
+					trait = dragon_slayer
+					trait = trained_dwarf
+					trait = dwarf_warrior
+				}
+			}
+			random = {
+				chance = 20
+				add_trait = dragon_slayer
+				remove_trait = great_axeman
+			}
+			character_event = { id = learnwarrior.3 days = 90 } ## I can try again!
+		}
+		if = {
+			limit = {
+				trait = trained_dwarf
+				age = 1
+				not = {
+					trait = dragon_slayer
+					trait = great_axeman
+					trait = dwarf_warrior
+				}
+			}
+			random = {
+				chance = 40
+				add_trait = great_axeman
+				remove_trait = trained_dwarf
+			}
+			character_event = { id = learnwarrior.3 days = 70 } ## I can try again!
+		}
+		if = {
+			limit = {
+				trait = dwarf_warrior
+				age = 1
+				not = {
+					trait = dragon_slayer
+					trait = great_axeman
+					trait = trained_dwarf
+				}
+			}
+			random = {
+				chance = 50
+				add_trait = trained_dwarf
+				remove_trait = dwarf_warrior
+			}
+			character_event = { id = learnwarrior.3 days = 60 } ## I can try again!
+		}
+		if = {
+			limit = {
+				age = 1
+				not = {
+					trait = dragon_slayer
+					trait = great_axeman
+					trait = trained_dwarf
+					trait = dwarf_warrior
+				}
+			}
+			random = {
+				chance = 30
+				add_trait = dwarf_warrior
+			}
+			character_event = { id = learnwarrior.3 days = 50 } ## I can try again!
+		}
+	}
+}
+
+

--- a/MEP/localisation/decision_craft_learning.csv
+++ b/MEP/localisation/decision_craft_learning.csv
@@ -1,0 +1,2 @@
+A_learn_craft;Learn or Improve Crafting.;;;;;;;;;x
+A_learn_craft_desc;Learn or improve crafting for a small price.;;;;;;;;;x

--- a/MEP/localisation/decision_war_learning.csv
+++ b/MEP/localisation/decision_war_learning.csv
@@ -1,0 +1,2 @@
+learn_warrior_abilities;Learn to become a true warrior.;;;;;;;;;x
+learn_warrior_abilities_desc;Learn or improve my fighting abilities.;;;;;;;;;x

--- a/MEP/localisation/event_craft_learning.csv
+++ b/MEP/localisation/event_craft_learning.csv
@@ -1,0 +1,9 @@
+EVTTITlearncraft.1;I should learn to craft.;;;;;;;;;x
+"EVTDESClearncraft.1;With some time effort and money invested, I think I can learn or improve my crafting.;;;;;;;;;x"
+EVTOPTAlearncraft.1;Learn or Improve Crafting.;;;;;;;;;x
+EVTOPTBlearncraft.1;Too expensive for me.;;;;;;;;;x
+EVTTITlearncraft.2;Time to learn.;;;;;;;;;x
+EVTDESClearncraft.2;I need to focus!;;;;;;;;;x
+EVTTITlearncraft.3;Enough time has passed.;;;;;;;;;x
+"EVTDESClearncraft.3;I think enough time has passed, I can try to improve again if I want.;;;;;;;;;x"
+EVTOPTAlearncraft.3;I can try again!;;;;;;;;;x

--- a/MEP/localisation/event_war_learning.csv
+++ b/MEP/localisation/event_war_learning.csv
@@ -1,0 +1,14 @@
+EVTTITlearnwarrior.1;Defence of my home is key.;;;;;;;;;x
+"EVTDESClearnwarrior.1;With some time effort and money invested, I am confident that I can become a true warrior.;;;;;;;;;x"
+EVTOPTAlearnwarrior.1;Learn to become a true elf Warrior!;;;;;;;;;x
+EVTOPTBlearnwarrior.1;Learn to become a true Dwarven Warrior!;;;;;;;;;x
+EVTOPTClearnwarrior.1;Too expensive for me.;;;;;;;;;x
+EVTTITlearnwarrior.2;Ready to become a true Elven Warrior.;;;;;;;;;x
+"EVTDESClearnwarrior.2;My teachers are ready and I am prepared, time to see if I can master these techniques!;;;;;;;;;x"
+EVTOPTAlearnwarrior.2;Train like you fight!;;;;;;;;;x
+EVTTITlearnwarrior.3;Enough time has passed.;;;;;;;;;x
+"EVTDESClearnwarrior.3;I think enough time has passed, I can try to improve again if I want.;;;;;;;;;x"
+EVTOPTAlearnwarrior.3;No more pushups!;;;;;;;;;x
+EVTTITlearnwarrior.4;Ready to become a true Dwarven Warrior.;;;;;;;;;x
+"EVTDESClearnwarrior.4;My teachers are ready and I am prepared, time to see if I can master these techniques!;;;;;;;;;x"
+EVTOPTAlearnwarrior.4;Train like you fight!;;;;;;;;;x


### PR DESCRIPTION
New event chain that can be accessed through the "middle earth
decicisions" menu that allows dwarf and noldor characters to learn
crafting skills and all dwarves and elves to learn the warrior
skills(traits).  Given enough time, money, prestige, and piety, a
character can attain the highest rank in either which may not be
balanced.  Needs more testing.